### PR TITLE
Fix #96: Client baseUrl field has incorrect JSON

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -959,6 +959,7 @@ func TestGocloak_CreateListGetUpdateDeleteClient(t *testing.T) {
 		Client{
 			ClientID: clientID,
 			Name:     GetRandomName("Name"),
+			BaseURL:  "http://example.com",
 		},
 	)
 	FailIfErr(t, err, "CreateClient failed")

--- a/models.go
+++ b/models.go
@@ -275,7 +275,7 @@ type Client struct {
 	AuthenticationFlowBindingOverrides map[string]string              `json:"authenticationFlowBindingOverrides,omitempty"`
 	AuthorizationServicesEnabled       bool                           `json:"authorizationServicesEnabled"`
 	AuthorizationSettings              *ResourceServerRepresentation  `json:"authorizationSettings,omitempty"`
-	BaseURL                            string                         `json:"baseURL,omitempty"`
+	BaseURL                            string                         `json:"baseUrl,omitempty"`
 	BearerOnly                         bool                           `json:"bearerOnly"`
 	ClientAuthenticatorType            string                         `json:"clientAuthenticatorType,omitempty"`
 	ClientID                           string                         `json:"clientId,omitempty"`


### PR DESCRIPTION
Fixes #96.

This fixes a JSON syntax problem with the Client model, BaseURL field, 